### PR TITLE
Add some tab-completion support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: perl6
 perl6:
   - latest
+  - 2017.08
 before_install:
   - wget https://github.com/zeromq/libzmq/releases/download/v4.2.2/zeromq-4.2.2.tar.gz
   - tar -xzvf zeromq-4.2.2.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: perl6
+env:
+  - MVM_SPESH_DISABLE=1
 perl6:
   - latest
   - 2017.08

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -1,11 +1,14 @@
+#!perl6
 
+use Log::Async;
 use nqp;
 
 %*ENV<RAKUDO_LINE_EDITOR> = 'none';
 %*ENV<RAKUDO_DISABLE_MULTILINE> = 0;
 
 my class Result {
-    has $.output;
+    has Str $.output;
+    has $.output-raw;
     has $.exception;
     has Bool $.incomplete;
     has $.stdout;
@@ -36,26 +39,70 @@ class Jupyter::Kernel::Sandbox is export {
         $!repl = REPL.new($!compiler, {});
     }
 
-    method eval(Str $code) {
+    method eval(Str $code, Bool :$no-persist) {
         my $stdout;
         my $*CTXSAVE = $!repl;
         my $*MAIN_CTX;
         my $*OUT = class { method print(*@args) { $stdout ~= @args.join }
                            method flush { } }
-        my $output = $!repl.repl-eval(
-            $code,
-            my $exception,
-            :outer_ctx($!save_ctx),
-            :interactive(1)
-        );
+        my $exception;
+        my $output =
+            try $!repl.repl-eval(
+                $code,
+                $exception,
+                :outer_ctx($!save_ctx),
+                :interactive(1)
+            );
+        my $caught;
+        $caught = $! if $!;
 
-        if $*MAIN_CTX {
+        if $*MAIN_CTX and !$no-persist {
             $!save_ctx := $*MAIN_CTX;
         }
 
-        $output = ~$exception with $exception;
+        $output = ~$_ with $exception // $caught;
         my $incomplete = so $!repl.input-incomplete($output);
-        return Result.new(:output($output.gist),:$stdout,:$exception, :$incomplete);
+        return Result.new(:output($output.gist),:output-raw($output),:$stdout,:$exception, :$incomplete);
+    }
+
+    sub extract-last-word(Str $line) {
+        # based on src/core/REPL.pm
+        my $m = $line ~~ /^ $<prefix>=[.*?] <|w>$<last_word>=[ [\w | '-' | '_' ]* ]$/;
+        return ( $line, '') unless $m;
+        ( ~$m<prefix>, ~$m<last_word> )
+    }
+
+    #! returns offset and list of completions
+    method completions($str) {
+        my ($prefix,$last) = extract-last-word($str);
+
+        # Handle methods ourselves.
+        if $prefix and substr($prefix,*-1,1) eq '.' {
+            my ($pre,$what) = extract-last-word(substr($prefix,0,*-1));
+            my $var = $what;
+            if $pre ~~ /$<sigil>=<[&$@%]>$/ {
+                my $sigil = ~$<sigil>;
+                $var = $sigil ~ $what;
+            }
+            my $res = self.eval($var ~ '.^methods(:all).map({.name}).join(" ")', :no-persist );
+            if !$res.exception && !$res.incomplete {
+                my @methods = $res.output-raw.split(' ');
+                return $prefix.chars, @methods.grep( { / ^ "$last" / } ).sort;
+            }
+        }
+
+        # Also handle variables
+        # todo.  REPL doesn't preserve ::.keys in context.
+        # if $prefix and substr($prefix,*-1,1) eq any('$','%','@','&') {
+        #     my $res = self.eval('::.keys.join(" ")');
+        #     say "want ----------- { $res.output-raw.perl } ";
+        #     my @possible = $res.output-raw.split(' ');
+        #     my @found = ( |@possible, |( CORE::.keys ) ).grep( { /^ "$last" / } ).sort;
+        #     return $prefix.chars, @found;
+        # }
+
+        my @completions = $!repl.completions-for-line($str,$str.chars-1).map({ .subst(/^ "$prefix" /,'') });
+        return $prefix.chars, @completions;
     }
 }
 

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -86,7 +86,7 @@ class Jupyter::Kernel::Sandbox is export {
             }
             my $res = self.eval($var ~ '.^methods(:all).map({.name}).join(" ")', :no-persist );
             if !$res.exception && !$res.incomplete {
-                my @methods = $res.output-raw.split(' ');
+                my @methods = $res.output-raw.split(' ').unique;
                 return $prefix.chars, @methods.grep( { / ^ "$last" / } ).sort;
             }
         }

--- a/t/02-sandbox.t
+++ b/t/02-sandbox.t
@@ -3,7 +3,7 @@ use lib 'lib';
 use Test;
 use Jupyter::Kernel::Sandbox;
 
-plan 24;
+plan 27;
 
 my $r = Jupyter::Kernel::Sandbox.new;
 
@@ -39,7 +39,7 @@ $res = $r.eval('my @bound := <1 2 3>;');
 ok !$res.exception, 'bound an array';
 $res = $r.eval('@bound[1]');
 is $res.output, "2", 'bound array';
-is $res.output-mime-type, 'text/plain';
+is $res.output-mime-type, 'text/plain', 'mime type';
 
 $res = $r.eval('say "<svg></svg>"');
 is $res.stdout, "<svg></svg>\n", 'generated svg on stdout';
@@ -51,3 +51,11 @@ is $res.output-mime-type, 'image/svg+xml', 'svg output mime type';
 
 $res = $r.eval('Any');
 is $res.output.perl, '"(Any)"', 'Any works';
+
+$res = $r.eval('die');
+is $res.output, 'Died', 'Die trapped';
+
+$res = $r.eval('sub foo { ... }; foo;');
+is $res.output, 'Stub code executed', 'trapped sub call that died';
+
+ok 1, 'still here';

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -18,7 +18,7 @@ is $pos, 1, 'offset';
 my $res = $r.eval(q[my $x = 'hello'; $x]);
 is $res.output, 'hello', 'output';
 ($pos,$completions) = $r.completions('$x.');
-is-deeply $completions, 'hello'.^methods(:all).map({.name}).sort, 'got methods for str';
+is-deeply $completions, 'hello'.^methods(:all).map({.name}).unique.sort, 'got methods for str';
 
 $res = $r.eval(q|class Foo { method barglefloober { ... } }; my $y = Foo.new;|);
 is $res.output, 'Foo.new', 'declared class';

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -17,8 +17,8 @@ is $pos, 1, 'offset';
 
 my $res = $r.eval(q[my $x = 'hello'; $x]);
 is $res.output, 'hello', 'output';
-($pos,$completions) = $r.completions('$x.');
-is-deeply $completions, 'hello'.^methods(:all).map({.name}).unique.sort, 'got methods for str';
+($pos,$completions) = $r.completions('$x.pe');
+is-deeply $completions, <perl perlseen permutations>, 'autocomplete for a string';
 
 $res = $r.eval(q|class Foo { method barglefloober { ... } }; my $y = Foo.new;|);
 is $res.output, 'Foo.new', 'declared class';

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl6
+use lib 'lib';
+use Test;
+use Jupyter::Kernel::Sandbox;
+
+plan 12;
+
+my $r = Jupyter::Kernel::Sandbox.new;
+
+my ($pos, $completions) = $r.completions('sa');
+is-deeply $completions, [<samecase samemark samewith say>], 'completions for "sa"';
+is $pos, 0, 'offset';
+
+($pos, $completions) = $r.completions(' sa');
+is-deeply $completions, [<samecase samemark samewith say>], 'completions for "sa"';
+is $pos, 1, 'offset';
+
+my $res = $r.eval(q[my $x = 'hello'; $x]);
+is $res.output, 'hello', 'output';
+($pos,$completions) = $r.completions('$x.');
+is-deeply $completions, 'hello'.^methods(:all).map({.name}).sort, 'got methods for str';
+
+$res = $r.eval(q|class Foo { method barglefloober { ... } }; my $y = Foo.new;|);
+($pos,$completions) = $r.completions('$y.barglefl');
+is-deeply $completions, $( 'barglefloober', ) , 'Declared a class and completion was a method';
+
+$res = $r.eval('my $abc = 12;');
+($pos,$completions) = $r.completions('$abc.is-prim');
+is-deeply $completions, $('is-prime', ), 'method with a -';
+
+($pos,$completions) = $r.completions('if 15.is-prim');
+is-deeply $completions, $( 'is-prime', ), 'is-prime for a number';
+
+($pos,$completions) = $r.completions('if "hello world".sa');
+is-deeply $completions, $( 'say', ), 'say for a string';
+
+$res = $r.eval('my $ghostbusters = 99');
+is $res.output, 99, 'made a var';
+($pos,$completions) = $r.completions('say $ghost');
+todo 'autocomplete variables';
+is-deeply $completions, $( '$ghostbusters', ), 'completed a variable';
+

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -3,7 +3,7 @@ use lib 'lib';
 use Test;
 use Jupyter::Kernel::Sandbox;
 
-plan 12;
+plan 13;
 
 my $r = Jupyter::Kernel::Sandbox.new;
 
@@ -21,6 +21,7 @@ is $res.output, 'hello', 'output';
 is-deeply $completions, 'hello'.^methods(:all).map({.name}).sort, 'got methods for str';
 
 $res = $r.eval(q|class Foo { method barglefloober { ... } }; my $y = Foo.new;|);
+is $res.output, 'Foo.new', 'declared class';
 ($pos,$completions) = $r.completions('$y.barglefl');
 is-deeply $completions, $( 'barglefloober', ) , 'Declared a class and completion was a method';
 


### PR DESCRIPTION
* Tab completion using CORE::.keys as in src/core/REPL
* Tab completion for methods using introspection.

Also:
* Fixed bug where is_complete request would eval code in the current context
* Better exception handling; running stub code in a function would cause the kernel to die.

![autocomplete](https://user-images.githubusercontent.com/58956/29986517-c6a2020e-8f31-11e7-83da-086ad18bc662.gif)
