### PR TITLE
Improve handling of output and stdout, and suppress  Nil expressions

### DIFF
--- a/lib/Jupyter/Kernel.pm6
+++ b/lib/Jupyter/Kernel.pm6
@@ -96,7 +96,7 @@ method run($spec-file!) {
                         }
                     }
                 }
-                if defined( $result.output-raw ) {
+                unless $result.output-raw === Nil {
                     $iopub.send: 'execute_result',
                                 { :$execution_count,
                                 :data( $result.output-mime-type => $result.output ),

--- a/lib/Jupyter/Kernel.pm6
+++ b/lib/Jupyter/Kernel.pm6
@@ -96,7 +96,7 @@ method run($spec-file!) {
                         }
                     }
                 }
-                if defined( $result.output) {
+                if defined( $result.output-raw ) {
                     $iopub.send: 'execute_result',
                                 { :$execution_count,
                                 :data( $result.output-mime-type => $result.output ),

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -10,7 +10,7 @@ use nqp;
 
 my class Result does Jupyter::Kernel::Response {
     has Str $.output;
-    has $.output-raw;
+    has $.output-raw is default(Nil);
     has $.exception;
     has Bool $.incomplete;
     has $.stdout;
@@ -74,7 +74,7 @@ class Jupyter::Kernel::Sandbox is export {
         if $no-persist {
             # use a temporary package
             $eval-code = qq:to/DONE/;
-            my \$out;
+            my \$out is default(Nil);
             package JupTemp \{
                 \$out = $( $code )
             \}
@@ -84,7 +84,8 @@ class Jupyter::Kernel::Sandbox is export {
             \$out;
             DONE
         }
-        my $output =
+
+        my $output is default(Nil) =
             try $!repl.repl-eval(
                 $eval-code,
                 $exception,
@@ -92,6 +93,8 @@ class Jupyter::Kernel::Sandbox is export {
                 :interactive(1)
             );
         $output = Nil if $output.?__hide;
+        $output = Nil if $output ~~ List and $output[*-1].?__hide;
+        $output = Nil if $output === Any;
         my $caught;
         $caught = $! if $!;
 

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -55,7 +55,10 @@ class Jupyter::Kernel::Sandbox is export {
         my $stdout;
         my $*CTXSAVE = $!repl;
         my $*MAIN_CTX;
-        my $*OUT = class { method print(*@args) { $stdout ~= @args.join }
+        my $*OUT = class { method print(*@args) {
+                              $stdout ~= @args.join;
+                              return True but role { method __hide { True } }
+                           }
                            method flush { } }
         my $exception;
         my $eval-code = $code;
@@ -73,7 +76,7 @@ class Jupyter::Kernel::Sandbox is export {
             $eval-code = qq:to/DONE/;
             my \$out;
             package JupTemp \{
-                \$out = $( $code)
+                \$out = $( $code )
             \}
             for (JupTemp::).keys \{
                 (JupTemp::)\{\$_\}:delete;
@@ -88,6 +91,7 @@ class Jupyter::Kernel::Sandbox is export {
                 :outer_ctx($!save_ctx),
                 :interactive(1)
             );
+        $output = Nil if $output.?__hide;
         my $caught;
         $caught = $! if $!;
 

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -92,9 +92,11 @@ class Jupyter::Kernel::Sandbox is export {
                 :outer_ctx($!save_ctx),
                 :interactive(1)
             );
-        $output = Nil if $output.?__hide;
-        $output = Nil if $output ~~ List and $output[*-1].?__hide;
-        $output = Nil if $output === Any;
+        given $output {
+            $_ = Nil if .?__hide;
+            $_ = Nil if $_ ~~ List and .elems and .[*-1].?__hide;
+            $_ = Nil if $_ === Any;
+        }
         my $caught;
         $caught = $! if $!;
 

--- a/t/02-sandbox.t
+++ b/t/02-sandbox.t
@@ -15,10 +15,10 @@ is $r.eval('my $x = 12; 123;').output, '123', 'made a var';
 is $r.eval('$x + 10;').output, "22", 'saved state';
 
 my $res = $r.eval('say "hello"');
+ok !$res.output-raw, 'no output, sent to stdout';
+is $res.stdout, "hello\n", 'right value on stdout';
 
 ok !$res.incomplete, 'not incomplete';
-ok $res.output, 'sent to stdout';
-is $res.stdout, "hello\n", 'right value on stdout';
 is $res.stdout-mime-type, 'text/plain', 'right mime-type on stdout';
 
 $res = $r.eval('floobody doop');

--- a/t/02-sandbox.t
+++ b/t/02-sandbox.t
@@ -3,7 +3,7 @@ use lib 'lib';
 use Test;
 use Jupyter::Kernel::Sandbox;
 
-plan 40;
+plan 46;
 
 my $r = Jupyter::Kernel::Sandbox.new;
 
@@ -49,8 +49,8 @@ $res = $r.eval('"<svg></svg>";');
 is $res.output, '<svg></svg>', 'generated svg output';
 is $res.output-mime-type, 'image/svg+xml', 'svg output mime type';
 
-$res = $r.eval('Any');
-is $res.output.perl, '"(Any)"', 'Any works';
+$res = $r.eval('Int');
+is $res.output.perl, '"(Int)"', 'Any works';
 
 $res = $r.eval('die');
 is $res.output, 'Died', 'Die trapped';
@@ -77,3 +77,12 @@ ok $res, "Produced output when ending with a comment";
 is $res.output, "hi", "got right output when ending with a comment";
 
 ok 1, 'still here';
+
+ok $r.eval('Any').output-raw === Nil, "Any becomes Nil";
+ok $r.eval('Nil').output-raw === Nil, "Nil becomes Nil";
+ok $r.eval('say 12').output-raw === Nil, "say becomes Nil";
+is $r.eval('my Int $x;').output, "(Int)", "Output from a type (undefined)";
+
+my $result = $r.eval('.say for 1..10', :store(7));
+ok $result.output-raw === Nil, "No output for multiple say's";
+is $result.stdout, (1..10).join("\n") ~ "\n", "right stdout for multiple say's";


### PR DESCRIPTION
This improves the handling of output and stdout:
 - `say` (and `print`) no longer return the expression being printed (bugfix)
 - if the last expression was a `say` (or `print`), the next output cell is suppressed
 - if the last expression is `Nil` or `Any`, the next output cell is suppressed

Note that undefined values (e.g. types) are still printed; the suppression only applies to `Nil` and `Any`.

This is consistent with other kernels, e.g. `say "hello"` should only print "hello", not generate an expression in an `Out[...]` cell.  (Also, e.g. `None` does not generate an `Out[..]` in ipython)
(edited)