### PR TITLE
Add Autocompletion for subs, π and ∞

### DIFF
--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
@@ -80,7 +80,7 @@ method complete($str,$cursor-pos,$sandbox) {
     }
 
     # Handle methods.
-    if $prefix and $prefix ~~ /'.'$/ {
+    if $prefix and $prefix ~~ / <!after '.'> '.'$/ {
        my ($pre,$what) = extract-last-word(substr($prefix,0,*-1));
        my $var = $what;
        if $pre ~~ /$<sigil>=<[&$@%]>$/ {
@@ -91,7 +91,7 @@ method complete($str,$cursor-pos,$sandbox) {
        $all = '' unless $last.chars; # local methods only unless at least 1 char
        my $eval-str = $var ~ '.^methods(' ~ $all ~ ').map({.name}).join(" ")';
        my $res = $sandbox.eval($eval-str, :no-persist );
-       if !$res.exception && !$res.incomplete {
+       if $res and !$res.exception and !$res.incomplete {
            my @methods = $res.output-raw.split(' ').unique;
            return $prefix.chars, $cursor-pos, @methods.grep( { / ^ "$last" / } ).sort;
        }
@@ -117,7 +117,7 @@ method complete($str,$cursor-pos,$sandbox) {
     # Look for subroutines/barewords
     if $last and $last ~~ /^ \w / {
        my @bare;
-       my %barewords = pi => 'π', inf => '∞', tau => 'τ';
+       my %barewords = pi => 'π', 'Inf' => '∞', tau => 'τ';
        with %barewords{ $last } {
            @bare.push: $_
        }

--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
@@ -117,7 +117,7 @@ method complete($str,$cursor-pos,$sandbox) {
     # Look for subroutines/barewords
     if $last and $last ~~ /^ \w / {
        my @bare;
-       my %barewords = pi => 'π', inf => '∞';
+       my %barewords = pi => 'π', inf => '∞', tau => 'τ';
        with %barewords{ $last } {
            @bare.push: $_
        }

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -7,7 +7,7 @@ use Jupyter::Kernel::Handler;
 unless %*ENV<P6_JUPYTER_TEST_AUTOCOMPLETE> {
     plan :skip-all<Set P6_JUPYTER_TEST_AUTOCOMPLETE to run these>;
 }
-plan 15;
+plan 16;
 
 unless %*ENV<MVM_SPESH_DISABLE> {
     diag "You may need to set MVM_SPESH_DISABLE=1 for these to pass";
@@ -17,11 +17,11 @@ my $r = Jupyter::Kernel::Sandbox.new;
 my $*JUPYTER = Jupyter::Kernel::Handler.new;
 
 my ($pos, $end, $completions) = $r.completions('sa', 2);
-is-deeply $completions, [<samecase samemark samewith say>], 'completions for "sa"';
+is-deeply $completions, [ <samecase samemark samewith say> ], 'completions for "sa"';
 is $pos, 0, 'offset';
 
 ($pos, $end, $completions) = $r.completions(' sa');
-is-deeply $completions, [<samecase samemark samewith say>], 'completions for "sa"';
+is-deeply $completions, [ <samecase samemark samewith say> ], 'completions for "sa"';
 is $pos, 1, 'offset';
 
 my $res = $r.eval(q[my $x = 'hello'; $x]);
@@ -50,10 +50,14 @@ is $res.output, 99, 'made a var';
 is-deeply $completions, $( '$ghostbusters', ), 'completed a variable';
 is $pos, 4, 'position is correct';
 
-# Generate and error but still get something sane
+# Generate an error but still get something sane
 my $from-here = q[my $d = Flannel.new; $d.ch].chars;
 my $str = q[my $d = Flannel.new; $d.ch  and say 'ok'];
 ($pos,$end,$completions) = $r.completions($str,$from-here);
-is $completions, <chars chdir chmod chomp chop chr chrs>, 'got something sane despite error'
+is $completions, <chars chdir chmod chomp chop chr chrs>, 'got something sane despite error';
+
+$res = $r.eval(q|sub flubber { 99 };|, :11store );
+($pos,$end,$completions) = $r.completions('flubb');
+is-deeply $completions, [ <flubber>, ], 'found a subroutine declaration';
 
 # vim: syn=perl6

--- a/t/05-autocomplete.t
+++ b/t/05-autocomplete.t
@@ -6,7 +6,7 @@ use Jupyter::Kernel::Sandbox::Autocomplete;
 
 logger.add-tap(  -> $msg { diag $msg<msg> } );
 
-plan 19;
+plan 20;
 
 my $c = Jupyter::Kernel::Sandbox::Autocomplete.new;
 
@@ -62,5 +62,9 @@ is $c.complete-ops('<'), (0, << < ≤ <= >>), 'less than';
 {
     my ($pos,$end,$got) = $c.complete('pi','pi'.chars,Nil);
     ok 'π' ∈ @$got, 'found π';
+}
+{
+    my ($pos,$end,$got) = $c.complete('tau','tau'.chars,Nil);
+    ok 'τ' ∈ @$got, 'found τ';
 }
 # vim: syn=perl6

--- a/t/05-autocomplete.t
+++ b/t/05-autocomplete.t
@@ -6,7 +6,7 @@ use Jupyter::Kernel::Sandbox::Autocomplete;
 
 logger.add-tap(  -> $msg { diag $msg<msg> } );
 
-plan 17;
+plan 19;
 
 my $c = Jupyter::Kernel::Sandbox::Autocomplete.new;
 
@@ -55,7 +55,12 @@ is $c.complete-ops('<'), (0, << < ≤ <= >>), 'less than';
     my ($pos,$end,$got) = $c.complete(':less-than-or-equal',':less-than'.chars,Nil);
     ok '≤' ∈ @$got, 'found ≤';
 }
-
-
-
+{
+    my ($pos,$end,$got) = $c.complete('say pi','say pi'.chars,Nil);
+    ok 'π' ∈ @$got, 'found π';
+}
+{
+    my ($pos,$end,$got) = $c.complete('pi','pi'.chars,Nil);
+    ok 'π' ∈ @$got, 'found π';
+}
 # vim: syn=perl6

--- a/t/05-autocomplete.t
+++ b/t/05-autocomplete.t
@@ -6,7 +6,7 @@ use Jupyter::Kernel::Sandbox::Autocomplete;
 
 logger.add-tap(  -> $msg { diag $msg<msg> } );
 
-plan 20;
+plan 21;
 
 my $c = Jupyter::Kernel::Sandbox::Autocomplete.new;
 
@@ -66,5 +66,9 @@ is $c.complete-ops('<'), (0, << < ≤ <= >>), 'less than';
 {
     my ($pos,$end,$got) = $c.complete('tau','tau'.chars,Nil);
     ok 'τ' ∈ @$got, 'found τ';
+}
+{
+    my ($pos,$end,$got) = $c.complete('1..Inf','1..Inf'.chars,Nil);
+    ok '∞' ∈ @$got, 'found ∞';
 }
 # vim: syn=perl6


### PR DESCRIPTION
Support autocompleting `pi` into` π`,` tau` into ` 𝜏`, `inf` into ` ∞`, and also find lexically scoped subroutines.