### PR TITLE
Support stderr and test output

### DIFF
--- a/lib/Jupyter/Kernel.pm6
+++ b/lib/Jupyter/Kernel.pm6
@@ -101,6 +101,9 @@ method run($spec-file!) {
                         }
                     }
                 }
+                if defined ($result.stderr ) {
+                    $iopub.send: 'stream', { :text( $result.stderr ), :name<stderr> }
+                }
                 unless $result.output-raw === Nil {
                     $iopub.send: 'execute_result',
                                 { :$execution_count,

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -54,14 +54,32 @@ class Jupyter::Kernel::Sandbox is export {
 
     method eval(Str $code, Bool :$no-persist, Int :$store) {
         my $stdout;
+        my $stderr;
         my $*CTXSAVE = $!repl;
         my $*MAIN_CTX;
         my $*JUPYTER = CALLERS::<$*JUPYTER> // Jupyter::Kernel::Handler.new;
-        my $*OUT = class { method print(*@args) {
-                              $stdout ~= @args.join;
-                              return True but role { method __hide { True } }
-                           }
-                           method flush { } }
+        my $*ERR = class {
+            method print(*@args) {
+                $stderr ~= @args.join;
+                return True but role { method __hide { True } }
+            }
+            method say(*@args) {
+                self.print(@args.map: * ~ "\n");
+            }
+            method flush { }
+        }
+        my $*OUT = class {
+            method print(*@args) {
+                $stdout ~= @args.join;
+                return True but role { method __hide { True } }
+            }
+            method say(*@args) {
+                self.print(@args.map: * ~ "\n");
+            }
+            method flush { }
+        }
+        $PROCESS::OUT = $*OUT;
+        $PROCESS::ERR = $*ERR;
         my $exception;
         my $eval-code = $code;
         if $store {
@@ -123,6 +141,7 @@ class Jupyter::Kernel::Sandbox is export {
             :output($gist),
             :output-raw($output),
             :$stdout,
+            :$stderr,
             :$exception,
             :$incomplete;
 

--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -78,6 +78,8 @@ class Jupyter::Kernel::Sandbox is export {
             }
             method flush { }
         }
+        # without setting $PROCESS:: variants, output from Test.pm6
+        # is not visible in the notebook.
         $PROCESS::OUT = $*OUT;
         $PROCESS::ERR = $*ERR;
         my $exception;

--- a/t/02-sandbox.t
+++ b/t/02-sandbox.t
@@ -3,7 +3,7 @@ use lib 'lib';
 use Test;
 use Jupyter::Kernel::Sandbox;
 
-plan 48;
+plan 50;
 
 my $r = Jupyter::Kernel::Sandbox.new;
 
@@ -20,6 +20,10 @@ is $res.stdout, "hello\n", 'right value on stdout';
 
 ok !$res.incomplete, 'not incomplete';
 is $res.stdout-mime-type, 'text/plain', 'right mime-type on stdout';
+
+$res = $r.eval('note "goodbye"');
+ok !$res.output-raw, 'no output, sent to stderr';
+is $res.stderr, "goodbye\n", 'correct value on stderr';
 
 $res = $r.eval('floobody doop');
 ok $res.exception, 'caught exception';


### PR DESCRIPTION
tl;dr:
* add `STDERR` support to the notebook
* enable the inclusion of output from `Test.pm6`

Recent convert to both Jupyter and Perl 6, I observed that `STDERR` was ending up on the console rather than appearing in the web UI. Furthermore, when creating a notebook to demonstrate some `Test.pm6` behaviour _all_ of its output went to the console.

Some digging led me to discover that `$stderr` was not being initialised in `Result`. Adding that, and then making the kernel publish it, made `note` work as desired.

To make `Test.pm6` output appear it was necessary to reassign `$PROCESS::OUT` and `ERR` to the custom streams within the `Sandbox` - which themselves needed a `.say` method (as that's what `Test.pm6` calls, not `print`).