### PR TITLE
force LANG= while testing ls

### DIFF
--- a/t/06-magic.t
+++ b/t/06-magic.t
@@ -156,7 +156,7 @@ class MockResult {
        }
 }
 {
-    my $cmd = 'ls /no/such/file/i/hope';
+    my $cmd = 'LANG= ls /no/such/file/i/hope';
     my $cell = ( '%% bash', $cmd).join("\n");
     my $magic = $m.find-magic($cell);
     ok $magic, 'found bash magic';


### PR DESCRIPTION
so the test will succeed whatever the locale setting of the installer.