### PR TITLE
Make sure the right compiler is fetched

### DIFF
--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -39,7 +39,7 @@ class Jupyter::Kernel::Sandbox is export {
     has $.completer = Jupyter::Kernel::Sandbox::Autocomplete.new;
 
     method TWEAK {
-        $!compiler := nqp::getcomp('perl6');
+        $!compiler := nqp::getcomp("Raku") // nqp::getcomp('perl6');
         $!repl = REPL.new($!compiler, {});
         self.eval(q:to/INIT/);
             my $Out = [];


### PR DESCRIPTION
The new name for the internal language name is "Raku", not "perl6"