### PR TITLE
Fix: complete function error traceback (type check fail in client)

### DIFF
--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
@@ -19,7 +19,7 @@ method !find-methods(:$sandbox, Bool :$all, :$var) {
        my $res = $sandbox.eval($eval-str, :no-persist );
        unless $res and !$res.exception and !$res.incomplete {
            debug 'autocomplete produced an error';
-           return;
+           return ();
        }
        $res.output-raw.split(' ').unique;
 }

--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
@@ -21,7 +21,7 @@ method !find-methods(:$sandbox, Bool :$all, :$var) {
            debug 'autocomplete produced an error';
            return ();
        }
-       $res.output-raw.split(' ').unique;
+       return $res.output-raw.split(' ').unique.Array.push('WHAT');
 }
 
 my @CANDIDATES;

--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
@@ -68,7 +68,7 @@ method complete($str,$cursor-pos=$str.chars,$sandbox = Nil) {
 
     my regex identifier { [ \w | '-' | '_' ]+ }
     my regex sigil { <[&$@%]> | '$*' }
-    my regex method-call { [ \w | '-' | '_' ]+ }
+    my regex method-call { '^' | '^'? <identifier> }
     my regex invocant {
        | '"' <-["]>+ '"'
        | [ \S+ ]
@@ -88,6 +88,7 @@ method complete($str,$cursor-pos=$str.chars,$sandbox = Nil) {
         when / <[⁰¹²³⁴⁵⁶⁷⁸⁹ⁱ⁺⁻⁼⁽⁾ⁿ]> $/ { return ($p-"$/".chars, $p, [ "$/" X~ superscripts ]); }
         when / <invocant> <!after '.'> '.' <!before '.'> <method-call>? $/ {
             my @methods = self!find-methods(:$sandbox, var => "$<invocant>", all => so $<method-call>);
+            @methods.append(Metamodel::ClassHOW.^methods(:all).map({"^" ~ .name}));
             my $meth = ~( $<method-call> // "" );
             my $len = $p - $meth.chars;
             return $len, $p, @methods.grep( { / ^ "$meth" / } ).sort;

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -46,6 +46,12 @@ is-deeply $completions, $( 'is-prime', ), 'is-prime for a number';
 ($pos,$end,$completions) = $r.completions('if "hello world".sa');
 is-deeply $completions, $("samecase", "samemark", "samespace", "say"), 'string methods';
 
+($pos,$end,$completions) = $r.completions('if "hello world".WHA');
+is-deeply $completions, $("WHAT", ), 'WHAT method';
+
+($pos,$end,$completions) = $r.completions('if "hello world".^add_metho');
+is-deeply $completions, $("^add_method", ), 'ClassHOW method';
+
 $res = $r.eval('my $ghostbusters = 99', :store);
 is $res.output, 99, 'made a var';
 ($pos,$end,$completions) = $r.completions('say $ghost');


### PR DESCRIPTION
Problem: `complete ^45.<Tab>` produces a type check error (issue #68)
Solution: return   `()` instead of `Nil`