### PR TITLE
Robustify: Completion catch errors and only display in log

### DIFF
--- a/lib/Jupyter/Kernel/Sandbox.pm6
+++ b/lib/Jupyter/Kernel/Sandbox.pm6
@@ -151,7 +151,13 @@ class Jupyter::Kernel::Sandbox is export {
     }
 
     method completions($str, $cursor-pos = $str.chars ) {
-        return self.completer.complete($str,$cursor-pos,self);
+        try {
+            return self.completer.complete($str,$cursor-pos,self);
+            CATCH {
+                error "Error completing <$str> at $cursor-pos: " ~ .message;
+                return $cursor-pos,$cursor-pos,();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Put a try catch around completion to avoid bad surprises for users and dev.
The error is in log anyway so no need to crash the kernel.