### PR TITLE
Feature: Asynchronous streams: See output from detached thread

### DIFF
--- a/lib/Jupyter/Kernel.pm6
+++ b/lib/Jupyter/Kernel.pm6
@@ -58,7 +58,6 @@ method run($spec-file!) {
         if $restart {
             info "Restarting\n";
             $iopub.send: 'stream', { :text( "The kernel is dead, long live the kernel!\n" ), :name<stdout> }
-            my $old = $.sandbox;
             $!sandbox = Jupyter::Kernel::Sandbox.new;
             $!execution_count = 1;
             $ctl.send: 'shutdown_reply', { :$restart }

--- a/lib/Jupyter/Kernel/Response.pm6
+++ b/lib/Jupyter/Kernel/Response.pm6
@@ -1,9 +1,6 @@
 role Jupyter::Kernel::Response {
     method output { ... }
     method output-mime-type { ... }
-    method stdout { ... }
-    method stdout-mime-type { ... }
-    method stderr { ... }
     method exception { ... }
     method incomplete { ... }
 }

--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.pm6
@@ -20,6 +20,7 @@ constant greater-than-operators = << > ≥ >= >>;
 constant superscripts = <⁰ ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁱ ⁺ ⁻ ⁼ ⁽ ⁾ ⁿ>;
 constant atomic-operators = <⚛= ⚛ ++⚛ ⚛++ --⚛ ⚛-- ⚛+= ⚛-= ⚛−=>;
 constant magic-start = ['#% javascript', '#% html', '#% latex', '%% bash', '%% run'];
+constant mop = <WHAT WHO HOW DEFINITE VAR>;
 
 method !find-methods(:$sandbox, Bool :$all, :$var) {
        my $eval-str = $var ~ '.^methods(' ~ (':all' x $all) ~ ').map({.name}).join(" ")';
@@ -28,7 +29,7 @@ method !find-methods(:$sandbox, Bool :$all, :$var) {
            debug 'autocomplete produced an error';
            return ();
        }
-       return $res.output-raw.split(' ').unique.Array.push('WHAT');
+       return $res.output-raw.split(' ').unique.Array.append(mop);
 }
 
 my @CANDIDATES;

--- a/t/02-sandbox.t
+++ b/t/02-sandbox.t
@@ -15,92 +15,115 @@ logger.add-tap: {
     note "# $_<msg>" if $VERBOSE;
 };
 
-my $r = Jupyter::Kernel::Sandbox.new;
 
+my $iopub_channel = Channel.new;
+my $r = Jupyter::Kernel::Sandbox.new(:$iopub_channel);
 ok defined($r), 'make a new sandbox';
 
-is $r.eval(q["hello"]).output, "hello", 'simple eval';
-is $r.eval("12").output, "12", 'stringify';
-is $r.eval('my $x = 12; 123;').output, '123', 'made a var';
-is $r.eval('$x + 10;').output, "22", 'saved state';
+sub stream {
+    my (@out, @err);
+    while my $msg = $iopub_channel.poll {
+        if $msg[0] eq 'display_data' {
+            @out.push($msg[1]<data>.values[0]);
+        }
+        next unless $msg[0] eq 'stream';
+        if $msg[1]<name> eq 'stdout' {
+            @out.push($msg[1]<text>);
+        } elsif $msg[1]<name> eq 'stderr' {
+            @err.push($msg[1]<text>);
+        }
+    }
+    return {:@out, :@err}
+}
 
-my $res = $r.eval('say "hello"');
-ok !$res.output-raw, 'no output, sent to stdout';
-is $res.stdout, "hello\n", 'right value on stdout';
+sub qa (Str $code, Bool :$no-persist, Int :$store){
+    return {res => $r.eval($code, :$no-persist, :$store), std=>stream};
+}
 
-ok !$res.incomplete, 'not incomplete';
-is $res.stdout-mime-type, 'text/plain', 'right mime-type on stdout';
+my ($a, $res);
 
-$res = $r.eval('note "goodbye"');
-ok !$res.output-raw, 'no output, sent to stderr';
-is $res.stderr, "goodbye\n", 'correct value on stderr';
+is qa(q["hello"])<res>.output, "hello", 'simple eval';
+is qa("12")<res>.output, "12", 'stringify';
+is qa('my $x = 12; 123;')<res>.output, '123', 'made a var';
+is qa('$x + 10;')<res>.output, "22", 'saved state';
 
-$res = $r.eval('floobody doop');
+$a = qa('say "hello"');
+ok !$a<res>.output-raw, 'no output, sent to stdout';
+is $a<std><out>[0], "hello\n", 'right value on stdout';
+
+ok !$a<res>.incomplete, 'not incomplete';
+is mime-type($a<std><out>[0]), 'text/plain', 'right mime-type on stdout';
+
+$a = qa('note "goodbye"');
+ok !$a<res>.output-raw, 'no output, sent to stderr';
+is $a<std><err>[0], "goodbye\n", 'correct value on stderr';
+
+$res = qa('floobody doop')<res>;
 ok $res.exception, 'caught exception';
 like ~$res.exception, /'Undeclared routines'/, 'error message';
 like ~$res.exception, /'doop'/, 'error message somewhat useful';
 is $res.exception.^name, 'X::Undeclared::Symbols', 'exception type';
 
-$res = $r.eval('for (1..10) {');
+$res = qa('for (1..10) {')<res>;
 ok $res.incomplete, 'identified incomplete input';
 
-$res = $r.eval('my @ints = <1 2 3>;');
+$res = qa('my @ints = <1 2 3>;')<res>;
 ok !$res.exception, 'made an array';
-$res = $r.eval('@ints[1]');
+$res = qa('@ints[1]')<res>;
 is $res.output, "2", 'array';
 
-$res = $r.eval('my @bound := <1 2 3>;');
+$res = qa('my @bound := <1 2 3>;')<res>;
 ok !$res.exception, 'bound an array';
-$res = $r.eval('@bound[1]');
+$res = qa('@bound[1]')<res>;
 is $res.output, "2", 'bound array';
 is $res.output-mime-type, 'text/plain', 'mime type';
 
-$res = $r.eval('say "<svg></svg>"');
-is $res.stdout, "<svg></svg>\n", 'generated svg on stdout';
-is $res.stdout-mime-type, 'image/svg+xml', 'svg mime type on stdout';
+$a = qa('say "<svg></svg>"');
+is $a<std><out>[0], "<svg></svg>\n", 'generated svg on stdout';
+is mime-type($a<std><out>[0]), 'image/svg+xml', 'svg mime type on stdout';
 
-$res = $r.eval('"<svg></svg>";');
+$res = qa('"<svg></svg>";')<res>;
 is $res.output, '<svg></svg>', 'generated svg output';
 is $res.output-mime-type, 'image/svg+xml', 'svg output mime type';
 
-$res = $r.eval('Int');
+$res = qa('Int')<res>;
 is $res.output.perl, '"(Int)"', 'Any works';
 
-$res = $r.eval('die');
+$res = qa('die')<res>;
 is $res.output, 'Died', 'Die trapped';
 
-$res = $r.eval('sub foo { ... }; foo;');
+$res = qa('sub foo { ... }; foo;')<res>;
 is $res.output, 'Stub code executed', 'trapped sub call that died';
 
-is $r.eval('123', :store(1)).output, "123", 'store eval in Out[1]';
-is $r.eval('Out[1]', :store(2)).output, "123", 'get Out[1]';
-is $r.eval('_2', :store(3)).output, "123", 'get _2';
-is $r.eval('_', :store(4)).output, "123", 'get _';
+is qa('123', :store(1))<res>.output, "123", 'store eval in Out[1]';
+is qa('Out[1]', :store(2))<res>.output, "123", 'get Out[1]';
+is qa('_2', :store(3))<res>.output, "123", 'get _2';
+is qa('_', :store(4))<res>.output, "123", 'get _';
 
-is $r.eval('my $y = 3; my $x = 99; $x + 1').output, "100", 'two statements';
-is $r.eval('my $yy = 3; my $xx = 99; $xx + 1', :store(5)).output, "100", 'two statements';
-is $r.eval('_').output, "100", 'saved the right thing';
-is $r.eval('_ + 1').output, "101", 'used _ in an expression';
+is qa('my $y = 3; my $x = 99; $x + 1')<res>.output, "100", 'two statements';
+is qa('my $yy = 3; my $xx = 99; $xx + 1', :store(5))<res>.output, "100", 'two statements';
+is qa('_')<res>.output, "100", 'saved the right thing';
+is qa('_ + 1')<res>.output, "101", 'used _ in an expression';
 
-is $r.eval('class Foo { method bar { ... } }', :no-persist).output, '(Foo)', 'class decl';
-is $r.eval('class Foo { method bar { ... } }', :no-persist).output, '(Foo)', 'class decl';
-is $r.eval('class Foo { method bar { ... } }').output, '(Foo)', 'no-persist a class';
+is qa('class Foo { method bar { ... } }', :no-persist)<res>.output, '(Foo)', 'class decl';
+is qa('class Foo { method bar { ... } }', :no-persist)<res>.output, '(Foo)', 'class decl';
+is qa('class Foo { method bar { ... } }')<res>.output, '(Foo)', 'no-persist a class';
 
-$res = $r.eval(q['hi'; # foo], :store(6));
+$res = qa(q['hi'; # foo], :store(6))<res>;
 ok $res, "Produced output when ending with a comment";
 is $res.output, "hi", "got right output when ending with a comment";
 
 ok 1, 'still here';
 
-ok $r.eval('Any').output-raw === Nil, "Any becomes Nil";
-ok $r.eval('Nil').output-raw === Nil, "Nil becomes Nil";
-ok $r.eval('say 12').output-raw === Nil, "say becomes Nil";
-is $r.eval('my Int $x;').output, "(Int)", "Output from a type (undefined)";
+ok qa('Any')<res>.output-raw === Nil, "Any becomes Nil";
+ok qa('Nil')<res>.output-raw === Nil, "Nil becomes Nil";
+ok qa('say 12')<res>.output-raw === Nil, "say becomes Nil";
+is qa('my Int $x;')<res>.output, "(Int)", "Output from a type (undefined)";
 
-my $result = $r.eval('.say for 1..10', :store(7));
-ok $result.output-raw === Nil, "No output for multiple say's";
-is $result.stdout, (1..10).join("\n") ~ "\n", "right stdout for multiple say's";
+$a = qa('.say for 1..10', :store(7));
+ok $a<res>.output-raw === Nil, "No output for multiple say's";
+is $a<std><out>.join, (1..10).join("\n") ~ "\n", "right stdout for multiple say's";
 
-$res = $r.eval('1/0');
+$res = qa('1/0')<res>;
 ok $res, 'survived exception';
 like $res.output, /:i 'attempt to divide' .* 'by zero' /, 'trapped 1/0 error';

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -15,8 +15,8 @@ unless %*ENV<MVM_SPESH_DISABLE> {
     diag "You may need to set MVM_SPESH_DISABLE=1 for these to pass";
 }
 
-my $r = Jupyter::Kernel::Sandbox.new;
-my $*JUPYTER = Jupyter::Kernel::Handler.new;
+my $iopub_channel = Channel.new;
+my $r = Jupyter::Kernel::Sandbox.new(:$iopub_channel);
 
 my ($pos, $end, $completions) = $r.completions('sa', 2);
 is-deeply $completions, [ <samecase samemark samewith say> ], 'completions for "sa"';

--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -5,9 +5,11 @@ use Jupyter::Kernel::Sandbox;
 use Jupyter::Kernel::Handler;
 use Log::Async;
 
-logger.send-to($*ERR);
+logger.add-tap( -> $msg { diag $msg<msg> } );
 
-unless %*ENV<P6_JUPYTER_TEST_AUTOCOMPLETE> {
+if %*ENV<P6_JUPYTER_TEST_AUTOCOMPLETE> {
+    plan 21;
+} else {
     plan :skip-all<Set P6_JUPYTER_TEST_AUTOCOMPLETE to run these>;
 }
 


### PR DESCRIPTION
This one is kind of hard.
Permit asynchronous io via a iopub_channel (as ipython)
Note that the iopub must be sent __ALL__ from the same thread, otherwise, the socket will be in an inconsistent state and this will break the client parsing.

Test case
```raku
start for 1..10  { .say; sleep 0.1; }
```

* __Before__ (Cannot see the 10 numbers printing)
```
In [27]: start for 1..10  { .say; sleep 0.1; }
1
Out[27]: Promise.new(scheduler =>
ThreadPoolScheduler.new(initial_threads => 0, max_threads => 64,
uncaught_handler => Callable), status => PromiseStatus::Planned)

In [28]:
```

* __After__ (Can see the 10 numbers in terminal)

```
In [6]: start for 1..10  { .say; sleep 0.1; }
1
2
Out[6]: Promise.new(scheduler => ThreadPoolScheduler.new(initial_threads
=> 0, max_threads => 64, uncaught_handler => Callable), status =>
PromiseStatus::Planned)

In [7]: 3
4
5
6
7
8
9
10
```