### PR TITLE
Merge order

### DIFF
--- a/lib/Jupyter/Kernel.rakumod
+++ b/lib/Jupyter/Kernel.rakumod
@@ -103,10 +103,9 @@ method run($spec-file!) {
     }
 
     # Iostream
-    start loop {
-        my ($tag, %dic) = $iopub_channel.receive;
+    $iopub_channel.Supply.tap( -> ($tag, %dic) {
         $iopub.send: $tag, %dic;
-    }
+    });
 
     # Shell
     my $promise = start {

--- a/lib/Jupyter/Kernel.rakumod
+++ b/lib/Jupyter/Kernel.rakumod
@@ -110,7 +110,6 @@ method run($spec-file!) {
 
     # Shell
     my $promise = start {
-    my $execution_count = 1;
     $!sandbox = Jupyter::Kernel::Sandbox.new(:$.handler, :$iopub_channel);
     self.register-ciao;
     loop {

--- a/lib/Jupyter/Kernel.rakumod
+++ b/lib/Jupyter/Kernel.rakumod
@@ -128,7 +128,7 @@ method run($spec-file!) {
                 my $magic = $.magics.find-magic($code);
                 my $result;
                 $result = .preprocess($code) with $magic;
-                $result //= $.sandbox.eval($code, :store($.execution_count));
+                $result //= $.sandbox.eval($code, :store($!execution_count));
                 if $magic {
                     with $magic.postprocess(:$code,:$result) -> $new-result {
                         $result = $new-result;

--- a/lib/Jupyter/Kernel/Service.rakumod
+++ b/lib/Jupyter/Kernel/Service.rakumod
@@ -39,12 +39,12 @@ method !hmac(@m) {
     hmac-hex $!key, @m[0] ~ @m[1] ~ @m[2] ~ @m[3], &sha256;
 }
 
-method read-message {
+method read-message($flags=0) {
     my @identities;
     my @message;
     my $separated = False;
     my $separator = buf8.new: "<IDS|MSG>".encode;
-    while $!socket.receive.data -> $data {
+    while $!socket.receive($flags).data -> $data {
         if !$separated {
             if $data eqv $separator  {
                 $separated = True;

--- a/t/02-sandbox.t
+++ b/t/02-sandbox.t
@@ -16,8 +16,9 @@ logger.add-tap: {
 };
 
 
-my $iopub_channel = Channel.new;
-my $r = Jupyter::Kernel::Sandbox.new(:$iopub_channel);
+my $iopub_supplier = Supplier.new;
+my $r = Jupyter::Kernel::Sandbox.new(:$iopub_supplier);
+my $iopub_channel = $iopub_supplier.Supply.Channel;
 ok defined($r), 'make a new sandbox';
 
 sub stream {

--- a/t/lib/Jupyter/Client.rakumod
+++ b/t/lib/Jupyter/Client.rakumod
@@ -52,11 +52,11 @@ method wait-history (Str(Cool) $pattern="") {
     return $.shell.read-message;
 }
 
-method wait-stdio {
+method read-stdio ($flags = 0) {
     # Call me after a request
     my @res; my %msg;
     repeat {
-        %msg = $.iopub.read-message;
+        %msg = $.iopub.read-message($flags);
         my %topush = %msg;
         @res.push(%topush);
     } until %msg<header><msg_type> eq 'status' and %msg<content><execution_state> eq 'idle';
@@ -65,7 +65,7 @@ method wait-stdio {
 
 method wait-result {
     # Call me after a request
-    my @msg = self.wait-stdio;
+    my @msg = self.read-stdio;
     my %result-msg = @msg.grep(*<header><msg_type> eq 'execute_result')[0];
     return %result-msg<content><data><text/plain>
 }


### PR DESCRIPTION
Hi Bduggan, always a pleasure to summit PR here.

This one is not critical but deserves explanations (sorry for making it so long):

* __Problem:__ For my Vim client [jupyter-vim](https://github.com/jupyter-vim/jupyter-vim) the connection I implemented, get some info from the kernel (pid, hostname). This comes from the iostream for Raku. But this one comes too late due to async iostream (old PR for thread io support)

* __Idea:__ So I wanted the `execute_reply` to wait for the stream `idle` was sent to the socket.

* __Solution:__ The solution I chose here (criticable of course) is to use the awesome `Async::Lock`, unlock when 'idle' is sent, they kernel can `execute_reply` and client is sure that the stream is in the socket upto `idle`.


PS 1: The python code: 
 In python, they flush, sleep, https://github.com/ipython/ipykernel/blob/ff122dd62388af07354cc209387dfa271294e8ee/ipykernel/kernelbase.py#L549-L556, flush again, send anything and Pool it. Too many contributors I guess.


```python
# Flush output before sending the reply.
sys.stdout.flush()
sys.stderr.flush()
# FIXME: on rare occasions, the flush doesn't seem to make it to the
# clients... This seems to mitigate the problem, but we definitely need
# to better understand what's going on.
if self._execute_sleep:
    time.sleep(self._execute_sleep)

...

sys.stdout.flush()
sys.stderr.flush()
self._publish_status(u'idle')
# flush to ensure reply is sent
self.control_stream.flush(zmq.POLLOUT)

```

 PS2: A screenshot of the Vim plugin:
![raku-jupyter-order](https://user-images.githubusercontent.com/6123962/78065596-e640fb00-7369-11ea-9f4e-29ad7b0db5af.png)

