### PR TITLE
Feature: Persistent language changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,6 @@ SEE ALSO
 
 KNOWN ISSUES
 ---------
-* Definitions of operators are not preserved (see https://github.com/Raku/old-issue-tracker/issues/6333)
-
 * Newly declared methods might not be available in autocompletion unless SPESH is disabled (see tests in [this PR](https://github.com/bduggan/p6-jupyter-kernel/pull/11)).
 
 THANKS

--- a/lib/Jupyter/Kernel/Handler.rakumod
+++ b/lib/Jupyter/Kernel/Handler.rakumod
@@ -9,6 +9,14 @@ has $.comms handles <comm-ids comm-names>
    = Jupyter::Kernel::Comms.new;
 has Array $.imports is rw;
 has Array $.keywords is rw;
+my Mu $lang = $?LANG;
+
+method set-lang(Mu $arg-lang) { $lang := $arg-lang; }
+
+method update-compiler(Mu $compiler) {
+    $compiler.parsegrammar($lang.slang_grammar('MAIN'));
+    $compiler.parseactions($lang.slang_actions('MAIN'));
+}
 
 method register-comm($name, &callback --> Nil) {
     $.comms.add-comm-callback($name,&callback);

--- a/lib/Jupyter/Kernel/Sandbox.rakumod
+++ b/lib/Jupyter/Kernel/Sandbox.rakumod
@@ -11,6 +11,7 @@ use nqp;
 
 state $iopub_supplier;
 
+
 sub mime-type($str) is export {
     return do given $str {
         when /:i ^ '<svg' / {
@@ -95,6 +96,7 @@ class Jupyter::Kernel::Sandbox is export {
                 my \\_$store = \$(
                     $code
                 );
+                \$*JUPYTER.set-lang( \$?LANG );
                 \$*JUPYTER.add-lexicals( MY::.keys );
                 \$Out[$store] := _$store;
                 _ = _$store;
@@ -124,6 +126,7 @@ class Jupyter::Kernel::Sandbox is export {
                 :interactive(1)
             );
             $gist = $output.gist;
+            $!handler.update-compiler($!compiler);
             CATCH {
                 default {
                     $exception = $_;

--- a/t/lib/Slang/TestWhatIs.rakumod
+++ b/t/lib/Slang/TestWhatIs.rakumod
@@ -1,0 +1,24 @@
+=begin pod
+
+use Slang::TestWhatIs;
+say what-is-test;  # OUTPUT: "test is nice"
+
+=end pod
+
+use nqp;
+use QAST:from<NQP>;
+
+role TestGrammar {
+    token term:sym<what-is-test> { <sym> };
+}
+
+role TestActions {
+    method term:sym<what-is-test> (Mu $/) {
+        return make QAST::SVal.new: :value('test is nice');
+    }
+}
+
+sub EXPORT(|) {
+    $*LANG.refine_slang('MAIN', TestGrammar, TestActions);
+    return {};
+}


### PR DESCRIPTION
Fix 2/3 of #85
1. OK: Slang persistent
2. OK: Operator persistent (I changed the doc in the PR)
3. NO: Pragma persistent.

The first commit (81f5cfd83c7ad1) is the real work (11 lines) the rest is only test and doc.