### PR TITLE
Feature: magics always

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ by the kernel.  See EXAMPLES.  The following magics are supported:
   if any lexical variables, subroutines, etc. are declared in FILENAME,
   they will become available in the notebook execution context.
 
+  * `%% always [SUBCOMMAND] CODE`: SUBCOMMAND defaults to `prepend` but can be:
+    * `prepend`: Prepend each cell by `CODE;\n`
+    * `append`: Append `;\nCODE` after each command
+    * `clear`: Clear all `always` registered actions
+    * `show`: Show `always` registered actions
+  You can combine it with another magic. For example:
+  `%% always prepend %% run file.raku`
+
 * __Comms:__  Comms allow for asynchronous communication between a notebook
 and the kernel.  For an example of using comms, see [this notebook](eg/comms.ipynb)
 

--- a/lib/Jupyter/Kernel/Magics.rakumod
+++ b/lib/Jupyter/Kernel/Magics.rakumod
@@ -247,8 +247,15 @@ method parse-magic($code is rw) {
     $magic-line ~~ /^ [ '#%' | '%%' ] / or return Nil;
     my $actions = Magic::Actions.new;
     my $match = Magic::Grammar.new.parse($magic-line,:$actions) or return Nil;
-    $code .= subst( $magic-line, '');
-    $code .= subst( /\n/, '');
+    # Parse full cell if always
+    if $match<magic><always> {
+        $match = Magic::Grammar.new.parse($code,:$actions);
+        $code = '';
+    # Parse only first line otherwise
+    } else {
+        $code .= subst( $magic-line, '');
+        $code .= subst( /\n/, '');
+    }
     return $match.made;
 }
 

--- a/lib/Jupyter/Kernel/Response.rakumod
+++ b/lib/Jupyter/Kernel/Response.rakumod
@@ -7,9 +7,9 @@ role Jupyter::Kernel::Response {
 }
 
 class Jupyter::Kernel::Response::Abort does Jupyter::Kernel::Response {
-  method output { "[got sigint on thread {$*THREAD.id}]" }
-  method output-mime-type { 'text/plain' }
-  method exception { True }
-  method incomplete { False }
-  method output-raw { 'aborted' }
+    method output { "[got sigint on thread {$*THREAD.id}]" }
+    method output-mime-type { 'text/plain' }
+    method exception { True }
+    method incomplete { False }
+    method output-raw { 'aborted' }
 }

--- a/lib/Jupyter/Kernel/Sandbox/Autocomplete.rakumod
+++ b/lib/Jupyter/Kernel/Sandbox/Autocomplete.rakumod
@@ -19,7 +19,8 @@ constant less-than-operators = << < ≤ <= >>;
 constant greater-than-operators = << > ≥ >= >>;
 constant superscripts = <⁰ ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁱ ⁺ ⁻ ⁼ ⁽ ⁾ ⁿ>;
 constant atomic-operators = <⚛= ⚛ ++⚛ ⚛++ --⚛ ⚛-- ⚛+= ⚛-= ⚛−=>;
-constant magic-start = ['#% javascript', '#% html', '#% latex', '%% bash', '%% run'];
+constant magic-start = ['#% javascript', '#% html', '#% latex', '%% bash', '%% run',
+    '%% always', '%% always prepend', '%% always append', '%% always show', '%% always clear'];
 constant mop = <WHAT WHO HOW DEFINITE VAR>;
 
 method !find-methods(:$sandbox, Bool :$all, :$var) {

--- a/t/20-end-to-end.t
+++ b/t/20-end-to-end.t
@@ -139,7 +139,12 @@ $cl.qa('$way = "";');
     $cl.qa('%% always clear my way  # GREP-TEST');
     $cl.qa('$way = "";');
 }
-## Celebrate: ... And did it my way
+$cl.qa('%% always clear my way  # GREP-TEST');
+$cl.qa('$way = "";');
+## Multiline: ... And did it my way
+is $cl.qa("%% always prepend  # GREP-TEST\n\$way ~= 'multi1-';  # GREP-TEST\n \n\$way ~= 'multi2-'; \n\n"), '', 'Always: register multiline';
+is $cl.qa('$way ~= "mid-";  # GREP-TEST'), 'multi1-multi2-mid-', 'Always: multiline 1';
+is $cl.qa('$way ~= "last";  # GREP-TEST'), 'multi1-multi2-mid-multi1-multi2-last', 'Always: multiline 2';
 $cl.qa('%% always clear my way  # GREP-TEST');
 
 # Test history

--- a/t/20-end-to-end.t
+++ b/t/20-end-to-end.t
@@ -52,7 +52,7 @@ my $spec = from-json($s_connection);
 sub spawn-kernel {
     my $lib = $?FILE.IO.parent.sibling('lib').Str;
     my $script = $?FILE.IO.parent.sibling('bin').child('jupyter-kernel.raku').Str;
-    return Proc::Async.new("perl6", "-I$lib", $script, $spec-file).start;
+    return Proc::Async.new("raku", "-I$lib", $script, $spec-file).start;
 }
 
 # Remove all 'GREP-TEST' in history <- run perl6
@@ -109,6 +109,38 @@ is $msg{'header'}{'msg_type'}, 'status', 'Order: 5. type = status';
 is $msg{'content'}{'execution_state'}, 'idle', 'Order: 5. content = idle';
 ### 3.*-1 No more
 is @stdout.elems, 0, 'Order: *. No more element in iopub';
+
+# Test always: I did it my way
+## Pre: ... Yes, there were times, I'm sure you knew
+$cl.qa('my $way = "";  # GREP-TEST');
+is $cl.qa('%% always $way ~= "pre1-";  # GREP-TEST'), '', 'Always: register pre1';
+is $cl.qa('%% always prepend $way ~= "pre2-";  # GREP-TEST'), '', 'Always: register pre2';
+## Show: ... When I bit off more than I could chew
+ok $cl.qa('%% always show me the way  # GREP-TEST') ~~ / 'pre1' / , 'Always: show';
+is $cl.qa('$way;  # GREP-TEST'), 'pre1-pre2-', 'Always: test1';
+## Clear: ... But through it all, when there was doubt
+$cl.qa('$way = "";  # GREP-TEST');
+$cl.qa('%% always clear my way  # GREP-TEST');
+is $cl.qa('$way;  # GREP-TEST'), '', 'New var';
+## Post: ... I ate it up and spit it out
+is $cl.qa('%% always append $way ~= "-post1";  # GREP-TEST'), '', 'Always: register post1';
+is $cl.qa('%% always append $way ~= "-post2";  # GREP-TEST'), '', 'Always: register post2';
+is $cl.qa('my $no-warn = $way;  # GREP-TEST'), '-post1-post2', 'Always: test post1';
+is $cl.qa('$no-warn = $way;  # GREP-TEST'), '-post1-post2-post1-post2', 'Always: test post2';
+$cl.qa('%% always clear my way # GREP-TEST');
+$cl.qa('$way = "";');
+## Combine: ... I faced it all and I stood tall
+{
+    my $file will leave {.unlink} = $*TMPDIR.child("test.$*PID");
+    $file.spurt: 'my $imported = "I traveled each and every highway";';
+    # Cannot make a GREP-TEST Here or it is considered as path
+    is $cl.qa("%% always prepend %% run $file"), '', 'Always: Combining with run';
+    is $cl.qa('$imported;  # GREP-TEST'), 'I traveled each and every highway', 'Always: Combined with run';
+    $cl.qa('%% always clear my way  # GREP-TEST');
+    $cl.qa('$way = "";');
+}
+## Celebrate: ... And did it my way
+$cl.qa('%% always clear my way  # GREP-TEST');
 
 # Test history
 $cl.wait-history;


### PR DESCRIPTION
Always `prepend` and `append` are implemented. As `show` and `clear` to inspect and remove them all. As conversed in issue #85
The first commit contains the real work. The rest is test and doc.

### Note on `t/20-end-to-end.t`
(I renamed it : 10 -> 20 for it to stay the last when adding more test)

The client is not dying sometimes => address already in use (9103 iopub)
For example when my tests did freeze a Ctrl-C killed the kernel but not the client.
```bash
pkill raku
P6_JUPYTER_TEST_END_TO_END=1 ra t/20-end-to-end.t
```
Or more wisely
```bash
netstat -laputn | grep 9103   # to find its pid (here 666)
kill -15 666
```

