### PR TITLE
Tolerant: Completion: Magic

### DIFF
--- a/t/04-completions.t
+++ b/t/04-completions.t
@@ -8,7 +8,7 @@ use Log::Async;
 logger.add-tap( -> $msg { diag $msg<msg> } );
 
 if %*ENV<P6_JUPYTER_TEST_AUTOCOMPLETE> {
-    plan 24;
+    plan 27;
 } else {
     plan :skip-all<Set P6_JUPYTER_TEST_AUTOCOMPLETE to run these>;
 }
@@ -96,6 +96,17 @@ ok 'strict' ∈ $completions, 'pragma no strict';
 
 ($pos,$end,$completions) = $r.completions('use li');
 ok 'lib' ∈ $completions, 'pragma use lib';
+
+# Magic
+($pos,$end,$completions) = $r.completions('%% al');
+ok '%% always prepend' ∈ $completions, 'magic always prepend';
+
+($pos,$end,$completions) = $r.completions('#%    r');
+ok '#%    run' ∈ $completions, 'magic run spaces';
+
+($pos,$end,$completions) = $r.completions('%%javas');
+ok '%%javascript' ∈ $completions, 'magic javascript no spaces';
+
 
 done-testing;
 


### PR DESCRIPTION
Better magic completion
```
%%r<un>
#%      java<script>
```
__Before:__ some magics where with `%%` others with `#%`. Only one space was necessary for completion


__Question:__ I had to repeat `and (so magic-words.grep(*.starts-with($rest)))` because if I affect it in the boolean context, its always false even : `and (my word =  magic-words.grep(*.starts-with($rest)); True)` or `and (my @words = Array.new(magic-words.grep(*.starts-with($rest)))) {
` makes the when `fails` do you have an idea why ?